### PR TITLE
Use `version` instead of `troopjs/version`.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ module.exports = function(grunt) {
 				"optimizeCss" : "none",
 				"skipDirOptimize" : true,
 				"keepBuildDir" : true,
-				"fileExclusionRegExp": /^(?:\.(?!travis|gitignore)|dist|node_modules|test|tasks|guides|jsduck|(?:version|Gruntfile)\.js|(?:package|bower)\.json)/,
+				"fileExclusionRegExp": /^(?:\.(?!travis|gitignore)|dist|node_modules|test|tasks|guides|jsduck|Gruntfile\.js|(?:package|bower)\.json)/,
 				"packages" : [{
 					"name": "text",
 					"location": "empty:"
@@ -118,7 +118,7 @@ module.exports = function(grunt) {
 					"location" : "bower_components/troopjs-requirejs"
 				}],
 				"rawText" : {
-					"troopjs/version" : "define([], <%= JSON.stringify(pkg.version) %>);\n"
+					"version" : "define([], <%= JSON.stringify(pkg.version) %>);\n"
 				}
 			},
 

--- a/mini.js
+++ b/mini.js
@@ -1,5 +1,5 @@
 define([
-	"./version",
+	"version",
 	"troopjs-browser/application/widget"
 ], function (version) {
 	return version;

--- a/version.js
+++ b/version.js
@@ -1,3 +1,0 @@
-define([ "json!./bower.json#version" ], function (version) {
-	return version;
-});


### PR DESCRIPTION
Use changes from troopjs/troopjs-core#152
